### PR TITLE
Changed colours of Joystick

### DIFF
--- a/lib/pages/game.dart
+++ b/lib/pages/game.dart
@@ -22,7 +22,7 @@ class GamePage extends StatelessWidget {
               children: [
                 // placeholder for game
                 Container(
-                  color: Color(0xFFDC143C),
+                  color: Color(0xFFFFFFFF),
                 ),
 
                 // joypad overlay

--- a/lib/widgets/joypad.dart
+++ b/lib/widgets/joypad.dart
@@ -43,7 +43,7 @@ class JoypadState extends State<Joypad> {
         child: GestureDetector(
           child: Container(
             decoration: BoxDecoration(
-              color: Color(0x88ffffff),
+              color: Color(0xFFDC143C).withOpacity(0.35),
               borderRadius: BorderRadius.circular(90),
             ),
             child: Center(
@@ -54,7 +54,7 @@ class JoypadState extends State<Joypad> {
                   width: 70,
                   child: Container(
                     decoration: BoxDecoration(
-                      color: Color(0xccffffff),
+                      color: Color(0xFFDC143C),
                       borderRadius: BorderRadius.circular(35),
                     ),
                   ),

--- a/lib/widgets/rightpad.dart
+++ b/lib/widgets/rightpad.dart
@@ -78,7 +78,7 @@ class ButtonState extends State<Button> {
       child: GestureDetector(
         child: Container(
           decoration: BoxDecoration(
-            color: Color(0x88ffffff),
+            color: Color(0xFFDC143C),
             borderRadius: BorderRadius.circular(90),
           ),
           child: SizedBox(


### PR DESCRIPTION
## Related Issues
Fixes #18 

## Description
I changed the colors of Joystick UI using the color codes given in the issue and the opacity of `35%`. For testing, I just commented out some part of the code which was at this time giving me getter stream null error and added `GamePage()` instead of `DiscoverDevices()` in `main.dart`.

Here is an image:

![WhatsApp Image 2020-10-03 at 3 42 01 AM](https://user-images.githubusercontent.com/51456744/94974093-20fb3a00-052b-11eb-8333-a5e424560ca6.jpeg)
